### PR TITLE
FEATURE: Now export to home folder (output.json)

### DIFF
--- a/src/img_visualizer.rs
+++ b/src/img_visualizer.rs
@@ -6,7 +6,7 @@ use iced::{
     Element, Length, Renderer, Sandbox,
 };
 
-use self::render_image::{init_json_obj, AnnotatedStore, Message, Step, ImageStepMessage};
+use self::render_image::{init_json_obj, AnnotatedStore, ImageStepMessage, Message, Step};
 
 #[path = "render_image.rs"]
 mod render_image;


### PR DESCRIPTION
Fixes: https://github.com/krshrimali/image-annotator-rust/issues/5

Uses `home` crate, and [once_cell](https://crates.io/crates/once_cell) for the static variable.