### PR TITLE
FEAT: Automate release candidates

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,21 @@
+name: Compile Binary (Release)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Prepare Release
+        run: cargo build --release

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install
+      - name: Install ATK
         run: sudo apt -y update && sudo apt -y install librust-atk-sys-dev
+      - name: Install GTK
+        run: sudo apt -y update && sudo apt -y install libgtk-3-dev
       - uses: actions/checkout@v2
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install
+        run: sudo apt -y update && sudo apt -y install librust-atk-sys-dev
       - uses: actions/checkout@v2
       - name: Build
         run: cargo build --verbose


### PR DESCRIPTION
First step: Adding GitHub workflow. Currently we don't have tests, but we should add one once we reach closer to v1.0.0